### PR TITLE
ci(release): write release notes to step summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,23 @@ jobs:
             @semantic-release/exec@7.0.2
             conventional-changelog-conventionalcommits@8.0.0
 
+      - name: Release Created
+        if:
+          ${{ steps.semantic-release.outputs.new_release_published == 'true' }}
+        id: release-notes
+        run: |
+          echo "## Release notes for created release" > $GITHUB_STEP_SUMMARY
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_SUMMARY
+          echo "${{ steps.semantic-release.outputs.new_release_notes }}" >> $GITHUB_SUMMARY
+          echo "EOF" >> $GITHUB_STEP_SUMMARY
+
+      - name: No release created
+        if:
+          ${{ steps.semantic-release.outputs.new_release_published != 'true' }}
+        id: no-release
+        run: |
+          echo "No new release was created." >> $GITHUB_STEP_SUMMARY
+
   floating-tag:
     needs: release
     if: ${{ needs.release.outputs.new_release_published == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,11 @@ jobs:
         id: release-notes
         run: |
           echo "## Release notes for created release" > "$GITHUB_STEP_SUMMARY"
-          echo "RELEASE_NOTES<<EOF" >> "$GITHUB_STEP_SUMMARY"
-          echo "${{ steps.semantic-release.outputs.new_release_notes }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "EOF" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "RELEASE_NOTES<<EOF"
+            echo "${{ steps.semantic-release.outputs.new_release_notes }}"
+            echo "EOF"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: No release created
         if:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          semantic_version: 24.2.3
+          semantic_version: v24.2.1
           extra_plugins: |
             @semantic-release/git@10.0.1
             @semantic-release/changelog@6.0.3
@@ -46,17 +46,17 @@ jobs:
           ${{ steps.semantic-release.outputs.new_release_published == 'true' }}
         id: release-notes
         run: |
-          echo "## Release notes for created release" > $GITHUB_STEP_SUMMARY
-          echo "RELEASE_NOTES<<EOF" >> $GITHUB_SUMMARY
-          echo "${{ steps.semantic-release.outputs.new_release_notes }}" >> $GITHUB_SUMMARY
-          echo "EOF" >> $GITHUB_STEP_SUMMARY
+          echo "## Release notes for created release" > "$GITHUB_STEP_SUMMARY"
+          echo "RELEASE_NOTES<<EOF" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.semantic-release.outputs.new_release_notes }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "EOF" >> "$GITHUB_STEP_SUMMARY"
 
       - name: No release created
         if:
           ${{ steps.semantic-release.outputs.new_release_published != 'true' }}
         id: no-release
         run: |
-          echo "No new release was created." >> $GITHUB_STEP_SUMMARY
+          echo "No new release was created." >> "$GITHUB_STEP_SUMMARY"
 
   floating-tag:
     needs: release


### PR DESCRIPTION
Write to step summary with release notes on created release, or a line saying no release created when it was not.

Downgrade semantic_version input used for semantic release to a version I know to have worked on other projects.